### PR TITLE
use upstream six instead of django vendored

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist =
     py{27,34}-django1.8
     py{27,34,35,36}-django1.11
     py{34,35,36}-django2.0
+    py{34,35,36,37,38}-django2.2
+    py{34,35,36,37,38}-django3.0
     report
 
 [testenv]
@@ -20,11 +22,15 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
+    py38: python3.8
 
 deps =
     django1.8:  django>=1.8, <1.9
     django1.11:  django>=1.11, <2.0
     django2.0:  django>=2.0, <2.1
+    django2.2: django>=2.2, <3.0
+    django3.0: django>=3.0, <3.1
     six
     coverage>=4.0
     coveralls>=1.0

--- a/yaa_settings/app_settings.py
+++ b/yaa_settings/app_settings.py
@@ -3,7 +3,7 @@ AppSettings class
 """
 import sys
 
-from django.utils import six
+import six
 from django.conf import settings
 
 


### PR DESCRIPTION
Django dropped six support for 3.0. See more at
https://docs.djangoproject.com/en/3.0/releases/3.0/